### PR TITLE
fix: parse separate lab/theory timetable timings and harden home widget

### DIFF
--- a/lib/core/utils/format_to_12_hour.dart
+++ b/lib/core/utils/format_to_12_hour.dart
@@ -18,3 +18,15 @@ String formatTo12Hour(String? timeString) {
     return timeString; // Return original if parsing fails
   }
 }
+
+/// Formats a `start – end` time range in 12-hour form, e.g. `"9:00 AM - 9:50 AM"`.
+/// Falls back to just the start time when the end is missing/malformed, and to an
+/// empty string when both are absent.
+String formatTimeRange(String? startTime, String? endTime) {
+  final start = formatTo12Hour(startTime);
+  final end = formatTo12Hour(endTime);
+
+  if (start.isEmpty) return end;
+  if (end.isEmpty) return start;
+  return '$start - $end';
+}

--- a/lib/core/utils/parse_class_time.dart
+++ b/lib/core/utils/parse_class_time.dart
@@ -1,0 +1,18 @@
+/// Safely parses a `HH:mm` class time (e.g. `"09:00"`) into a [DateTime] anchored
+/// to today. Returns `null` for anything that isn't a valid time — including the
+/// `"-"` placeholder VTOP emits for empty grid cells — so callers can skip or
+/// gracefully degrade instead of throwing during `build()`.
+DateTime? parseClassTime(String? timeString) {
+  if (timeString == null) return null;
+
+  final parts = timeString.trim().split(':');
+  if (parts.length != 2) return null;
+
+  final hour = int.tryParse(parts[0].trim());
+  final minute = int.tryParse(parts[1].trim());
+  if (hour == null || minute == null) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+
+  final now = DateTime.now();
+  return DateTime(now.year, now.month, now.day, hour, minute);
+}

--- a/lib/features/home/view/widgets/upcoming_classes/upcoming_classes_card.dart
+++ b/lib/features/home/view/widgets/upcoming_classes/upcoming_classes_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:vit_ap_student_app/core/models/timetable.dart';
 import 'package:vit_ap_student_app/core/utils/format_to_12_hour.dart';
+import 'package:vit_ap_student_app/core/utils/parse_class_time.dart';
 
 class UpcomingClassCard extends StatelessWidget {
   final Day classInfo;
@@ -46,7 +47,8 @@ class UpcomingClassCard extends StatelessWidget {
                           width: 4,
                         ),
                         Text(
-                          formatTo12Hour(classInfo.startTime),
+                          formatTimeRange(
+                              classInfo.startTime, classInfo.endTime),
                           style:
                               Theme.of(context).textTheme.titleMedium?.copyWith(
                                     fontWeight: FontWeight.w600,
@@ -122,7 +124,7 @@ class UpcomingClassCard extends StatelessWidget {
             ),
           ),
         ),
-        classInfo.courseType!.contains('TH')
+        (classInfo.courseType ?? '').contains('TH')
             ? Positioned(
                 bottom: -26,
                 right: -15,
@@ -147,19 +149,18 @@ class UpcomingClassCard extends StatelessWidget {
 
   (String, Color, Color) _getClassStatus(Day classInfo) {
     final now = DateTime.now();
-    final startTimeString = classInfo.startTime?.trim();
-    final endTimeString = classInfo.endTime?.trim();
 
-// Parse start time
-    final startParts =
-        startTimeString?.split(':').map(int.parse).toList() ?? [];
-    final parsedStartTime =
-        DateTime(now.year, now.month, now.day, startParts[0], startParts[1]);
-
-// Parse end time
-    final endParts = endTimeString?.split(':').map(int.parse).toList() ?? [];
-    final parsedEndTime =
-        DateTime(now.year, now.month, now.day, endParts[0], endParts[1]);
+    // Missing or malformed times (e.g. the "-" placeholder) must not throw and
+    // crash the card — fall back to a neutral "Scheduled" status instead.
+    final parsedStartTime = parseClassTime(classInfo.startTime);
+    final parsedEndTime = parseClassTime(classInfo.endTime);
+    if (parsedStartTime == null || parsedEndTime == null) {
+      return (
+        'Scheduled',
+        Colors.grey.shade400.withValues(alpha: 0.4),
+        Colors.grey.shade700,
+      );
+    }
 
     if (now.isBefore(parsedStartTime)) {
       return (

--- a/lib/features/home/view/widgets/upcoming_classes/upcoming_classes_carousel.dart
+++ b/lib/features/home/view/widgets/upcoming_classes/upcoming_classes_carousel.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:vit_ap_student_app/core/models/timetable.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
 import 'package:vit_ap_student_app/core/utils/get_classes.dart';
+import 'package:vit_ap_student_app/core/utils/parse_class_time.dart';
 import 'package:vit_ap_student_app/features/home/view/widgets/timetable_empty_state.dart';
 import 'package:vit_ap_student_app/features/home/view/widgets/upcoming_classes/carousel_indicator.dart';
 import 'package:vit_ap_student_app/features/home/view/widgets/upcoming_classes/upcoming_classes_card.dart';
@@ -94,17 +95,10 @@ class _UpcomingClassesCarouselState
     final now = DateTime.now();
 
     for (int i = 0; i < classes.length; i++) {
-      final classItem = classes[i];
-      if (classItem.startTime == null) continue;
-      final parsedTime = DateFormat('HH:mm').parse(classItem.startTime!);
-
-      final classStartDateTime = DateTime(
-        now.year,
-        now.month,
-        now.day,
-        parsedTime.hour,
-        parsedTime.minute,
-      );
+      // Skip classes whose start time is missing or malformed (e.g. "-") instead
+      // of throwing and taking down the whole home screen.
+      final classStartDateTime = parseClassTime(classes[i].startTime);
+      if (classStartDateTime == null) continue;
 
       if (classStartDateTime.isAfter(now)) {
         return i;

--- a/lib/features/timetable/view/widgets/schedule_timeline.dart
+++ b/lib/features/timetable/view/widgets/schedule_timeline.dart
@@ -61,10 +61,7 @@ class ScheduleTimeline extends StatelessWidget {
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                formatTo12Hour(startTime),
-                style: const TextStyle(fontSize: 16),
-              ),
+              _buildTimeRange(context, startTime),
               const SizedBox(width: 8),
               _buildClassInfoCard(context),
             ],
@@ -72,6 +69,27 @@ class ScheduleTimeline extends StatelessWidget {
           const SizedBox(height: 8),
         ],
       ),
+    );
+  }
+
+  Widget _buildTimeRange(BuildContext context, String? startTime) {
+    final endLabel = formatTo12Hour(classInfo.endTime);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          formatTo12Hour(startTime),
+          style: const TextStyle(fontSize: 16),
+        ),
+        if (endLabel.isNotEmpty)
+          Text(
+            endLabel,
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+      ],
     );
   }
 

--- a/rust/src/api/vtop/parser/timetable_parser.rs
+++ b/rust/src/api/vtop/parser/timetable_parser.rs
@@ -29,6 +29,7 @@ fn parse_timetable_direct(html: String) -> Timetable {
         end_time: String,
         name: String,
         class_nbr: String,
+        is_lab: bool,
     }
 
     let mut weekly_timetable = Timetable {
@@ -48,7 +49,11 @@ fn parse_timetable_direct(html: String) -> Timetable {
     let document = Html::parse_document(&html);
     let rows_selector = Selector::parse("tr").unwrap();
     let mut raw_slots: Vec<RawSlot> = Vec::new();
-    let mut timings_temp: Vec<Timing> = Vec::new();
+    // Theory classes and lab classes have their own timing rows in the grid.
+    // Rows 0/1 hold the theory Start/End timings; rows 2/3 hold the lab Start/End
+    // timings. Column indices are shared between the theory and lab rows.
+    let mut theory_timings: Vec<Timing> = Vec::new();
+    let mut lab_timings: Vec<Timing> = Vec::new();
     let mut count_for_offset = 0;
     let table_selector = Selector::parse("tbody").unwrap();
     let mut table = document.select(&table_selector);
@@ -126,20 +131,24 @@ fn parse_timetable_direct(html: String) -> Timetable {
                             let paragraphs: Vec<_> =
                                 cells[7].select(&Selector::parse("p").unwrap()).collect();
                             if paragraphs.len() >= 2 {
+                                // The slot paragraph can span several indented lines
+                                // (e.g. "L23+L24\n   - "), so collapse all whitespace
+                                // and drop the lone "-" separator token before the venue.
                                 let slot_text = paragraphs[0]
                                     .text()
                                     .collect::<Vec<_>>()
-                                    .join("")
-                                    .trim()
-                                    .replace(" - ", "")
-                                    .replace(" -", "")
-                                    .to_string();
+                                    .join(" ")
+                                    .split_whitespace()
+                                    .filter(|tok| *tok != "-")
+                                    .collect::<Vec<_>>()
+                                    .join(" ");
                                 let venue_text = paragraphs[1]
                                     .text()
                                     .collect::<Vec<_>>()
-                                    .join("")
-                                    .trim()
-                                    .to_string();
+                                    .join(" ")
+                                    .split_whitespace()
+                                    .collect::<Vec<_>>()
+                                    .join(" ");
 
                                 if !slot_text.is_empty() && !venue_text.is_empty() {
                                     course_to_slot_venue
@@ -194,32 +203,40 @@ fn parse_timetable_direct(html: String) -> Timetable {
                 }
 
                 for (index, val) in cells.iter().enumerate() {
-                    if count_for_offset < 2 {
+                    if count_for_offset < 4 {
+                        let cell_text = val
+                            .text()
+                            .collect::<Vec<_>>()
+                            .join("")
+                            .trim()
+                            .replace("\t", "")
+                            .replace("\n", "");
                         if count_for_offset == 0 {
-                            let timing = Timing {
+                            // Theory start times
+                            theory_timings.push(Timing {
                                 serial: index.to_string(),
-                                start_time: val
-                                    .text()
-                                    .collect::<Vec<_>>()
-                                    .join("")
-                                    .trim()
-                                    .replace("\t", "")
-                                    .replace("\n", ""),
+                                start_time: cell_text,
                                 end_time: "".to_string(),
-                            };
-                            timings_temp.push(timing);
+                            });
                         } else if count_for_offset == 1 {
-                            if let Some(timing) = timings_temp.get_mut(index) {
-                                timing.end_time = val
-                                    .text()
-                                    .collect::<Vec<_>>()
-                                    .join("")
-                                    .trim()
-                                    .replace("\t", "")
-                                    .replace("\n", "");
+                            // Theory end times
+                            if let Some(timing) = theory_timings.get_mut(index) {
+                                timing.end_time = cell_text;
+                            }
+                        } else if count_for_offset == 2 {
+                            // Lab start times
+                            lab_timings.push(Timing {
+                                serial: index.to_string(),
+                                start_time: cell_text,
+                                end_time: "".to_string(),
+                            });
+                        } else if count_for_offset == 3 {
+                            // Lab end times
+                            if let Some(timing) = lab_timings.get_mut(index) {
+                                timing.end_time = cell_text;
                             }
                         }
-                    } else if count_for_offset > 3 {
+                    } else {
                         let class_name = val
                             .text()
                             .collect::<Vec<_>>()
@@ -309,6 +326,9 @@ fn parse_timetable_direct(html: String) -> Timetable {
                                             .unwrap_or(&"".to_string())
                                             .to_string()
                                     },
+                                    // Day rows alternate THEORY (even offset) / LAB (odd
+                                    // offset). Lab rows need the lab timing columns.
+                                    is_lab: count_for_offset % 2 == 1,
                                 };
                                 raw_slots.push(slot);
                             }
@@ -322,9 +342,15 @@ fn parse_timetable_direct(html: String) -> Timetable {
         return weekly_timetable;
     }
 
-    // Assign timings to slots
+    // Assign timings to slots. Lab slots use the lab timing row, theory slots use
+    // the theory timing row (they share column serials but have different times).
     for slot in &mut raw_slots {
-        if let Some(times) = timings_temp.iter().find(|t| t.serial == slot.serial) {
+        let timings = if slot.is_lab {
+            &lab_timings
+        } else {
+            &theory_timings
+        };
+        if let Some(times) = timings.iter().find(|t| t.serial == slot.serial) {
             slot.start_time = times.start_time.clone();
             slot.end_time = times.end_time.clone();
         }

--- a/rust/tests/timetable_parser_test.rs
+++ b/rust/tests/timetable_parser_test.rs
@@ -1,0 +1,72 @@
+use lib_vtop::api::vtop::parser::timetable_parser::parse_timetable;
+
+/// A trimmed slice of a real Fall 2026-27 VTOP timetable page, kept inline so the
+/// test carries no external fixture (and never bloats the shared library).
+///
+/// It preserves the exact grid layout that exposed the bug:
+///   * the course tbody has the CSE4007 Embedded Theory + Embedded Lab rows,
+///   * the grid tbody has all four header rows (THEORY Start/End, LAB Start/End)
+///     at full width so column indices line up like the real page, plus the FRI
+///     THEORY/LAB day pair.
+///
+/// The theory rows and lab rows carry DIFFERENT timings, so a lab slot that reads
+/// its time from the theory row lands on a "-" / wrong value — the exact defect.
+fn sample_html() -> String {
+    r#"<!DOCTYPE html><html><body><table>
+  <tbody>
+    <tr><td>2</td><td>General (Semester)</td><td>CSE4007 - Digital Image Processing ( Embedded Theory )</td><td>3 0 0 0 3.0</td><td>-</td><td>Regular</td><td>AP2026272000042</td><td><p>A1+TA1 - </p><p>G17-AB-2</p></td><td>Sucharitha M - SENSE</td></tr>
+    <tr><td>3</td><td>General (Semester)</td><td>CSE4007 - Digital Image Processing ( Embedded Lab )</td><td>0 0 2 0 1.0</td><td>-</td><td>Regular</td><td>AP2026272000235</td><td><p>L23+L24 - </p><p>114-AB-2</p></td><td>Sucharitha M - SENSE</td></tr>
+  </tbody>
+  <tbody>
+    <tr><td>THEORY</td><td>Start</td><td>08:00</td><td>09:00</td><td>09:01</td><td>10:00</td><td>10:01</td><td>11:00</td><td>11:01</td><td>12:00</td><td>12:01</td><td>-</td><td>Lunch</td><td>14:00</td><td>14:01</td><td>15:00</td><td>15:01</td><td>16:00</td><td>16:01</td><td>17:00</td><td>17:01</td><td>18:00</td><td>-</td></tr>
+    <tr><td>End</td><td>08:50</td><td>09:50</td><td>09:51</td><td>10:50</td><td>10:51</td><td>11:50</td><td>11:51</td><td>12:50</td><td>12:51</td><td>-</td><td>Lunch</td><td>14:50</td><td>14:51</td><td>15:50</td><td>15:51</td><td>16:50</td><td>16:51</td><td>17:50</td><td>17:51</td><td>18:50</td><td>-</td></tr>
+    <tr><td>LAB</td><td>Start</td><td>08:00</td><td>08:50</td><td>08:51</td><td>09:50</td><td>09:51</td><td>10:40</td><td>10:41</td><td>11:40</td><td>11:41</td><td>12:30</td><td>Lunch</td><td>14:00</td><td>14:01</td><td>14:50</td><td>14:51</td><td>15:50</td><td>15:51</td><td>16:40</td><td>16:41</td><td>17:40</td><td>18:30</td></tr>
+    <tr><td>End</td><td>08:50</td><td>09:40</td><td>09:41</td><td>10:40</td><td>10:41</td><td>11:30</td><td>11:31</td><td>12:30</td><td>12:31</td><td>13:10</td><td>Lunch</td><td>14:50</td><td>14:51</td><td>15:40</td><td>15:41</td><td>16:40</td><td>16:41</td><td>17:30</td><td>17:31</td><td>18:30</td><td>19:10</td></tr>
+    <tr><td>FRI</td><td>THEORY</td><td>TCC1</td><td>TB1</td><td>-</td><td>TA1-CSE4007-ETH-G17-AB-2-ALL</td><td>-</td><td>F1</td><td>-</td><td>TE1</td><td>SD2</td><td>-</td><td>Lunch</td><td>C2</td><td>-</td><td>TB2</td><td>-</td><td>TA2</td><td>-</td><td>F2</td><td>-</td><td>TEE2</td><td>-</td></tr>
+    <tr><td>LAB</td><td>L19</td><td>L20</td><td>--</td><td>L21</td><td>--</td><td>L22</td><td>--</td><td>L23-CSE4007-ELA-114-AB-2-ALL</td><td>--</td><td>L24-CSE4007-ELA-114-AB-2-ALL</td><td>Lunch</td><td>L49</td><td>--</td><td>L50</td><td>--</td><td>L51</td><td>--</td><td>L52</td><td>--</td><td>L53</td><td>L54</td></tr>
+  </tbody>
+</table></body></html>"#
+    .to_string()
+}
+
+#[test]
+fn theory_and_lab_slots_use_their_own_timings() {
+    let tt = parse_timetable(sample_html());
+
+    let friday = &tt.friday;
+    assert_eq!(
+        friday.len(),
+        2,
+        "expected one theory + one lab class on Friday"
+    );
+
+    // Theory class TA1 (grid column 4) -> theory timings 10:00 / 10:50.
+    let theory = friday
+        .iter()
+        .find(|c| c.course_type == "ETH")
+        .expect("theory class missing");
+    assert_eq!(theory.start_time, "10:00");
+    assert_eq!(theory.end_time, "10:50");
+
+    // Lab class L23+L24 (grid columns 8 & 10) -> LAB timings 11:40 / 13:10.
+    // Before the fix this reused the theory row (12:00 / "-") and produced the
+    // broken "-" / "-" class shown on the home screen.
+    let lab = friday
+        .iter()
+        .find(|c| c.course_type == "ELA")
+        .expect("lab class missing");
+    assert_eq!(lab.start_time, "11:40");
+    assert_eq!(lab.end_time, "13:10");
+    assert_ne!(lab.start_time, "-");
+    assert_ne!(lab.end_time, "-");
+
+    // The two consecutive lab periods collapse into a single class...
+    assert_eq!(lab.slot, "L23+L24 -");
+    // ...and the slot string carries no stray newline from the multi-line cell.
+    assert!(
+        !lab.slot.contains('\n'),
+        "slot should not contain a newline"
+    );
+    assert_eq!(lab.venue, "114-AB-2");
+    assert_eq!(lab.faculty, "Sucharitha M");
+}

--- a/test/core/utils/parse_class_time_test.dart
+++ b/test/core/utils/parse_class_time_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vit_ap_student_app/core/utils/parse_class_time.dart';
+
+void main() {
+  group('parseClassTime', () {
+    test('parses a valid HH:mm time to today', () {
+      final result = parseClassTime('09:05');
+      final now = DateTime.now();
+      expect(result, isNotNull);
+      expect(result!.year, now.year);
+      expect(result.month, now.month);
+      expect(result.day, now.day);
+      expect(result.hour, 9);
+      expect(result.minute, 5);
+    });
+
+    test('tolerates surrounding whitespace', () {
+      expect(parseClassTime('  14:30 '), isNotNull);
+      expect(parseClassTime('14:30')!.hour, 14);
+    });
+
+    // Regression: the "-" placeholder from empty VTOP grid cells used to throw a
+    // FormatException and blank the home-screen upcoming-class widget.
+    test('returns null for the "-" placeholder', () {
+      expect(parseClassTime('-'), isNull);
+    });
+
+    test('returns null for null, empty and malformed input', () {
+      expect(parseClassTime(null), isNull);
+      expect(parseClassTime(''), isNull);
+      expect(parseClassTime('9'), isNull);
+      expect(parseClassTime('09:00:00'), isNull);
+      expect(parseClassTime('ab:cd'), isNull);
+    });
+
+    test('returns null for out-of-range values', () {
+      expect(parseClassTime('24:00'), isNull);
+      expect(parseClassTime('10:60'), isNull);
+      expect(parseClassTime('-1:00'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Type of Change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [x] `rust` — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Related Issue

Closes #33 #15 

## Description

The Fall 2026-27 timetable introduced separate timings for labs vs. theory (previously identical). The Rust grid parser only captured the theory timing rows and reused them for every slot, so lab classes got wrong times — and when a lab column's theory cell was empty, the lab class came out with start_time: "-", end_time: "-". That malformed data then threw an unhandled exception in the Flutter home-screen "upcoming class" widget, replacing it with a blank gray box.

This PR fixes the parser to read lab timings from their own header rows, hardens the affected Flutter widgets against malformed timings, and additionally surfaces the class end time (not just the start) on the home widget and the timetable page.

## Changes Made

rust/.../timetable_parser.rs: The grid <tbody> has 4 header rows — rows 0/1 = THEORY start/end, rows 2/3 = LAB start/end (rows 2/3 were previously discarded). Now captures both into theory_timings and lab_timings, tags each RawSlot with is_lab (day rows alternate THEORY on even offsets / LAB on odd), and assigns each slot its matching timing array.
rust/.../timetable_parser.rs: Fixed a pre-existing slot-string bug where a lab's multi-line <p> cell left an embedded newline ("L23+L24\n -"); now collapses whitespace → clean "L23+L24 -".
lib/core/utils/parse_class_time.dart (new): Safe HH:mm → DateTime? parser returning null for "-"/malformed/out-of-range input.
upcoming_classes_carousel.dart & upcoming_classes_card.dart: Use the safe parser; malformed classes are skipped for "next class" selection and show a neutral "Scheduled" status instead of throwing. Also made the courseType Lottie check null-safe.
lib/core/utils/format_to_12_hour.dart: Added formatTimeRange(start, end) helper (falls back to start-only when end is missing).
upcoming_classes_card.dart: Home upcoming-class card now shows start - end (e.g. 9:00 AM - 9:50 AM).
schedule_timeline.dart: Timetable page now shows the end time stacked under the start time in the timeline's time column.
Tests: rust/tests/timetable_parser_test.rs (real-data slice, asserts lab L23+L24 → 11:40–13:10) and test/core/utils/parse_class_time_test.dart.

-
## Screenshots

<table>
  <tr>
    <th align="center">Before</th>
    <th align="center" colspan="2">After</th>
  </tr>
  <tr>
    <td align="center">
      <img height="720" alt="Before UI"
        src="https://github.com/user-attachments/assets/4b48c442-a1a3-4f58-ab96-f0eccbd3ac15" />
    </td>
    <td align="center">
      <img height="720" alt="After UI 2"
        src="https://github.com/user-attachments/assets/ad0d7c6a-21c4-4334-ae86-b5d67c336058" />
    </td>
    <td align="center">
      <img height="720" alt="After UI 1"
        src="https://github.com/user-attachments/assets/baada3fa-a4e3-490a-a9c9-30d4c425d3ec" />
    </td>
    
  </tr>
</table>

## Checklist

### Flutter

- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes
- [x] Ran `dart run build_runner build --delete-conflicting-outputs` (required if any model, provider, or ObjectBox entity was added or modified)
- [x] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

- [x] `cargo fmt` run inside `rust/`
- [x] `cargo clippy` passes with no new warnings inside `rust/`
- [x] `cargo test` passes inside `rust/`
- [x] Ran `flutter_rust_bridge_codegen generate` and committed the updated `lib/src/rust/` bindings (required if any `#[frb]` function signature changed)

### Testing

- [x] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [ ] Existing features unaffected by this change
