### PR TITLE
fix last syned timer

### DIFF
--- a/lib/features/attendance/view/pages/attendance_page.dart
+++ b/lib/features/attendance/view/pages/attendance_page.dart
@@ -70,8 +70,14 @@ class AttendancePageState extends ConsumerState<AttendancePage>
     await ref
         .read(attendanceViewModeProvider.notifier)
         .refreshAttendance(silentRefresh: silentRefresh);
-    lastSynced = DateTime.now();
-    await saveLastSynced();
+    // Only stamp "last synced" when the refresh actually succeeded. The view
+    // model swallows failures into its error state (e.g. a cancelled/failed
+    // OTP or network error), so advancing the timer unconditionally would lie.
+    final state = ref.read(attendanceViewModeProvider);
+    if (state != null && !state.hasError) {
+      lastSynced = DateTime.now();
+      await saveLastSynced();
+    }
   }
 
   bool _shouldRefresh() {

--- a/lib/features/auth/view/widgets/login_otp_bottom_sheet.dart
+++ b/lib/features/auth/view/widgets/login_otp_bottom_sheet.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pinput/pinput.dart';
 import 'package:vit_ap_student_app/core/common/widget/loader.dart';
@@ -25,7 +26,8 @@ class _LoginOtpSheet extends ConsumerStatefulWidget {
   ConsumerState<_LoginOtpSheet> createState() => _LoginOtpSheetState();
 }
 
-class _LoginOtpSheetState extends ConsumerState<_LoginOtpSheet> {
+class _LoginOtpSheetState extends ConsumerState<_LoginOtpSheet>
+    with WidgetsBindingObserver {
   final _pinController = TextEditingController();
   final _focusNode = FocusNode();
   String? _errorMessage;
@@ -36,15 +38,35 @@ class _LoginOtpSheetState extends ConsumerState<_LoginOtpSheet> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _startCooldown();
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _cooldownTimer?.cancel();
     _pinController.dispose();
     _focusNode.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // When the user leaves to read the OTP (e.g. Gmail) and returns, the soft
+    // keyboard was dismissed and `autofocus` does not re-fire. Re-request focus
+    // and force the keyboard back so they can type without tapping the field.
+    if (state == AppLifecycleState.resumed) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (_focusNode.hasFocus) {
+          // Focus was retained but the keyboard is hidden — reshow it.
+          SystemChannels.textInput.invokeMethod<void>('TextInput.show');
+        } else {
+          _focusNode.requestFocus();
+        }
+      });
+    }
   }
 
   Future<void> _submit() async {

--- a/lib/features/auth/view/widgets/login_otp_bottom_sheet.dart
+++ b/lib/features/auth/view/widgets/login_otp_bottom_sheet.dart
@@ -319,6 +319,7 @@ class _LoginOtpSheetState extends ConsumerState<_LoginOtpSheet>
                   child: ElevatedButton(
                     onPressed: isLoading ? null : _submit,
                     style: ElevatedButton.styleFrom(
+                      elevation: 0,
                       backgroundColor: theme.colorScheme.secondaryContainer,
                       minimumSize: const Size.fromHeight(48),
                       shape: RoundedRectangleBorder(

--- a/lib/features/digital_assignment/view/pages/digital_assignment_page.dart
+++ b/lib/features/digital_assignment/view/pages/digital_assignment_page.dart
@@ -57,9 +57,13 @@ class _DigitalAssignmentPageState extends ConsumerState<DigitalAssignmentPage>
     await ref
         .read(digitalAssignmentViewModelProvider.notifier)
         .refreshDigitalAssignments(silentRefresh: silentRefresh);
-    setState(() {
-      lastSynced = DateTime.now();
-    });
+    // Only stamp "last synced" when the refresh actually succeeded.
+    final state = ref.read(digitalAssignmentViewModelProvider);
+    if (state != null && !state.hasError) {
+      setState(() {
+        lastSynced = DateTime.now();
+      });
+    }
   }
 
   @override

--- a/lib/features/home/view/pages/exam_schedule_page.dart
+++ b/lib/features/home/view/pages/exam_schedule_page.dart
@@ -67,8 +67,12 @@ class _MyExamScheduleState extends ConsumerState<ExamSchedulePage>
         .read(examScheduleViewModelProvider.notifier)
         .refreshExamSchedule();
     await AnalyticsService.logEvent('refresh_exam_schedule');
-    lastSynced = DateTime.now();
-    await saveLastSynced();
+    // Only stamp "last synced" when the refresh actually succeeded.
+    final state = ref.read(examScheduleViewModelProvider);
+    if (state != null && !state.hasError) {
+      lastSynced = DateTime.now();
+      await saveLastSynced();
+    }
   }
 
   void _autoSelectUpcomingTab(List<ExamSchedule> schedule) {

--- a/lib/features/home/view/pages/marks_page.dart
+++ b/lib/features/home/view/pages/marks_page.dart
@@ -67,10 +67,14 @@ class _MarksPageState extends ConsumerState<MarksPage>
   }
 
   Future<void> refreshMarksData() async {
-    await ref.watch(marksViewModelProvider.notifier).refreshMarks();
+    await ref.read(marksViewModelProvider.notifier).refreshMarks();
     await AnalyticsService.logEvent('refresh_marks');
-    lastSynced = DateTime.now();
-    await saveLastSynced();
+    // Only stamp "last synced" when the refresh actually succeeded.
+    final state = ref.read(marksViewModelProvider);
+    if (state != null && !state.hasError) {
+      lastSynced = DateTime.now();
+      await saveLastSynced();
+    }
   }
 
   @override

--- a/lib/features/home/view/pages/outing/general_outing_history_page.dart
+++ b/lib/features/home/view/pages/outing/general_outing_history_page.dart
@@ -37,18 +37,21 @@ class _GeneralOutingHistoryPageState
     super.dispose();
   }
 
-  Future<void> _fetchData() async {
-    await ref
+  Future<bool> _fetchData() async {
+    return ref
         .read(generalOutingReportsViewModelProvider.notifier)
         .fetchGeneralOutingReports();
   }
 
   Future<void> _refreshData() async {
     await AnalyticsService.logEvent('refresh_general_outing_history');
-    setState(() {
-      lastSynced = DateTime.now();
-    });
-    await _fetchData();
+    final didSync = await _fetchData();
+    // Only stamp "last synced" when a fresh remote copy was actually fetched.
+    if (didSync && mounted) {
+      setState(() {
+        lastSynced = DateTime.now();
+      });
+    }
   }
 
   DateTime? _parseDate(String dateStr) {

--- a/lib/features/home/view/pages/outing/weekend_outing_history_page.dart
+++ b/lib/features/home/view/pages/outing/weekend_outing_history_page.dart
@@ -37,18 +37,21 @@ class _WeekendOutingHistoryPageState
     super.dispose();
   }
 
-  Future<void> _fetchData() async {
-    await ref
+  Future<bool> _fetchData() async {
+    return ref
         .read(weekendOutingReportsViewModelProvider.notifier)
         .fetchWeekendOutingReports();
   }
 
   Future<void> _refreshData() async {
     await AnalyticsService.logEvent('refresh_weekend_outing_history');
-    setState(() {
-      lastSynced = DateTime.now();
-    });
-    await _fetchData();
+    final didSync = await _fetchData();
+    // Only stamp "last synced" when a fresh remote copy was actually fetched.
+    if (didSync && mounted) {
+      setState(() {
+        lastSynced = DateTime.now();
+      });
+    }
   }
 
   List<WeekendOutingReport> _getFilteredAndSortedReports(

--- a/lib/features/home/viewmodel/outing_reports_viewmodel.dart
+++ b/lib/features/home/viewmodel/outing_reports_viewmodel.dart
@@ -21,7 +21,11 @@ class GeneralOutingReportsViewModel extends _$GeneralOutingReportsViewModel {
     return null;
   }
 
-  Future<void> fetchGeneralOutingReports({bool silentRefresh = false}) async {
+  /// Returns `true` only when a fresh copy was successfully fetched from the
+  /// remote. Falling back to cache (offline, or a failed remote fetch while
+  /// cache exists) returns `false`, so callers don't advance the "last synced"
+  /// timer on a stale result.
+  Future<bool> fetchGeneralOutingReports({bool silentRefresh = false}) async {
     // Check internet connectivity
     final isConnected = await InternetConnection().hasInternetAccess;
 
@@ -45,7 +49,7 @@ class GeneralOutingReportsViewModel extends _$GeneralOutingReportsViewModel {
           'User credentials not found. Please login again.',
           StackTrace.current,
         );
-        return;
+        return false;
       }
 
       final res = await _outingRemoteRepository.fetchGeneralOutingReports(
@@ -59,12 +63,12 @@ class GeneralOutingReportsViewModel extends _$GeneralOutingReportsViewModel {
           if (state?.value == null || state!.value!.isEmpty) {
             state = AsyncValue.error(failure.message, StackTrace.current);
           }
-          break;
+          return false;
         case Right(value: final reports):
           // Save to cache and update state
           await _outingLocalRepository.saveGeneralOutingReports(reports);
           state = AsyncValue.data(reports);
-          break;
+          return true;
       }
     } else {
       // No internet - load from cache
@@ -77,6 +81,7 @@ class GeneralOutingReportsViewModel extends _$GeneralOutingReportsViewModel {
           StackTrace.current,
         );
       }
+      return false;
     }
   }
 }
@@ -93,7 +98,11 @@ class WeekendOutingReportsViewModel extends _$WeekendOutingReportsViewModel {
     return null;
   }
 
-  Future<void> fetchWeekendOutingReports({bool silentRefresh = false}) async {
+  /// Returns `true` only when a fresh copy was successfully fetched from the
+  /// remote. Falling back to cache (offline, or a failed remote fetch while
+  /// cache exists) returns `false`, so callers don't advance the "last synced"
+  /// timer on a stale result.
+  Future<bool> fetchWeekendOutingReports({bool silentRefresh = false}) async {
     // Check internet connectivity
     final isConnected = await InternetConnection().hasInternetAccess;
 
@@ -117,7 +126,7 @@ class WeekendOutingReportsViewModel extends _$WeekendOutingReportsViewModel {
           'User credentials not found. Please login again.',
           StackTrace.current,
         );
-        return;
+        return false;
       }
 
       final res = await _outingRemoteRepository.fetchWeekendOutingReports(
@@ -131,12 +140,12 @@ class WeekendOutingReportsViewModel extends _$WeekendOutingReportsViewModel {
           if (state?.value == null || state!.value!.isEmpty) {
             state = AsyncValue.error(failure.message, StackTrace.current);
           }
-          break;
+          return false;
         case Right(value: final reports):
           // Save to cache and update state
           await _outingLocalRepository.saveWeekendOutingReports(reports);
           state = AsyncValue.data(reports);
-          break;
+          return true;
       }
     } else {
       // No internet - load from cache
@@ -149,6 +158,7 @@ class WeekendOutingReportsViewModel extends _$WeekendOutingReportsViewModel {
           StackTrace.current,
         );
       }
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `rust` — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Related Issue

Closes #25 

## Description

- only update "last synced" when a refresh actually succeeds
- reopen keyboard in login OTP sheet on app resume

## Changes Made

- Pages did await refresh(); lastSynced = DateTime.now(); unconditionally. The view models never throw — they convert failures into error state — so the timestamp always advanced (OTP cancel, network error, etc.).
- Made _LoginOtpSheetState a WidgetsBindingObserver and, on AppLifecycleState.resumed, re-request focus (and if focus was retained but the keyboard hidden, force it via SystemChannels.textInput TextInput.show).

-

## Screenshots / Recording

<!-- Required for any UI change. Drag and drop here. Delete this section if not applicable. -->

| Before | After |
|--------|-------|
|        |       |

## Checklist

### Flutter

- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes
- [x] Ran `dart run build_runner build --delete-conflicting-outputs` (required if any model, provider, or ObjectBox entity was added or modified)
- [ ] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

- [ ] `cargo fmt` run inside `rust/`
- [ ] `cargo clippy` passes with no new warnings inside `rust/`
- [ ] `cargo test` passes inside `rust/`
- [ ] Ran `flutter_rust_bridge_codegen generate` and committed the updated `lib/src/rust/` bindings (required if any `#[frb]` function signature changed)

### Testing

- [x] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [ ] Existing features unaffected by this change
