### PR TITLE
add in app demo mode

### DIFF
--- a/assets/demo/demo_dataset.json
+++ b/assets/demo/demo_dataset.json
@@ -1,0 +1,552 @@
+{
+  "user": {
+    "profile": {
+      "application_number": "2024043196",
+      "student_name": "Demo Student",
+      "dob": "01-Jan-2003",
+      "gender": "Male",
+      "blood_group": "O+",
+      "email": "demo.student2021@vitapstudent.ac.in",
+      "base64_pfp": null,
+      "grade_history": {
+        "credits_registered": "160",
+        "credits_earned": "160",
+        "cgpa": "8.72",
+        "courses": [
+          {
+            "course_code": "CSE1001",
+            "course_title": "Problem Solving and Programming",
+            "course_type": "ELA",
+            "credits": "4",
+            "grade": "S",
+            "exam_month": "Dec-2021",
+            "course_distribution": "CBL"
+          },
+          {
+            "course_code": "CSE2001",
+            "course_title": "Data Structures and Algorithms",
+            "course_type": "ETL",
+            "credits": "4",
+            "grade": "A",
+            "exam_month": "May-2022",
+            "course_distribution": "CBL"
+          },
+          {
+            "course_code": "CSE2005",
+            "course_title": "Operating Systems",
+            "course_type": "ETL",
+            "credits": "4",
+            "grade": "B",
+            "exam_month": "Dec-2022",
+            "course_distribution": "CBL"
+          },
+          {
+            "course_code": "CSE3001",
+            "course_title": "Database Management Systems",
+            "course_type": "ETL",
+            "credits": "4",
+            "grade": "A",
+            "exam_month": "May-2023",
+            "course_distribution": "CBL"
+          }
+        ]
+      },
+      "mentor_details": {
+        "faculty_id": "VITAP0999",
+        "faculty_name": "Dr. Sample Mentor",
+        "faculty_designation": "Associate Professor",
+        "school": "School of Computer Science and Engineering",
+        "cabin": "AB-1, 502-C",
+        "faculty_department": "Computer Science and Engineering",
+        "faculty_email": "sample.mentor@vitap.ac.in",
+        "faculty_intercom": "9123",
+        "faculty_mobile_number": "90000 00000"
+      }
+    },
+    "timetable": {
+      "Monday": [
+        {
+          "start_time": "09:00",
+          "end_time": "09:50",
+          "course_name": "Design and Analysis of Algorithms",
+          "slot": "A1",
+          "venue": "AB1-201",
+          "faculty": "Dr. Sample Faculty A",
+          "course_code": "CSE3011",
+          "course_type": "Theory"
+        },
+        {
+          "start_time": "11:00",
+          "end_time": "11:50",
+          "course_name": "Computer Networks",
+          "slot": "B1",
+          "venue": "AB1-305",
+          "faculty": "Dr. Sample Faculty B",
+          "course_code": "CSE3012",
+          "course_type": "Theory"
+        }
+      ],
+      "Tuesday": [
+        {
+          "start_time": "10:00",
+          "end_time": "10:50",
+          "course_name": "Machine Learning",
+          "slot": "C1",
+          "venue": "AB2-108",
+          "faculty": "Dr. Sample Faculty C",
+          "course_code": "CSE3013",
+          "course_type": "Theory"
+        },
+        {
+          "start_time": "14:00",
+          "end_time": "15:40",
+          "course_name": "Computer Networks Lab",
+          "slot": "L31+L32",
+          "venue": "AB1-Lab-4",
+          "faculty": "Dr. Sample Faculty B",
+          "course_code": "CSE3012",
+          "course_type": "Lab"
+        }
+      ],
+      "Wednesday": [
+        {
+          "start_time": "09:00",
+          "end_time": "09:50",
+          "course_name": "Design and Analysis of Algorithms",
+          "slot": "A1",
+          "venue": "AB1-201",
+          "faculty": "Dr. Sample Faculty A",
+          "course_code": "CSE3011",
+          "course_type": "Theory"
+        }
+      ],
+      "Thursday": [
+        {
+          "start_time": "10:00",
+          "end_time": "10:50",
+          "course_name": "Machine Learning",
+          "slot": "C1",
+          "venue": "AB2-108",
+          "faculty": "Dr. Sample Faculty C",
+          "course_code": "CSE3013",
+          "course_type": "Theory"
+        },
+        {
+          "start_time": "11:00",
+          "end_time": "11:50",
+          "course_name": "Computer Networks",
+          "slot": "B1",
+          "venue": "AB1-305",
+          "faculty": "Dr. Sample Faculty B",
+          "course_code": "CSE3012",
+          "course_type": "Theory"
+        }
+      ],
+      "Friday": [
+        {
+          "start_time": "14:00",
+          "end_time": "15:40",
+          "course_name": "Machine Learning Lab",
+          "slot": "L39+L40",
+          "venue": "AB2-Lab-2",
+          "faculty": "Dr. Sample Faculty C",
+          "course_code": "CSE3013",
+          "course_type": "Lab"
+        }
+      ],
+      "Saturday": [],
+      "Sunday": []
+    },
+    "attendance": [
+      {
+        "class_number": "CH2024250100001",
+        "course_code": "CSE3011",
+        "course_name": "Design and Analysis of Algorithms",
+        "course_type": "Theory",
+        "course_type_code": "TH",
+        "course_slot": "A1",
+        "faculty": "Dr. Sample Faculty A",
+        "attended_classes": "28",
+        "total_classes": "30",
+        "attendance_percentage": "93",
+        "attendance_between_percentage": "90-100",
+        "debar_status": "Not Debarred",
+        "course_id": "CSE3011-A1-TH"
+      },
+      {
+        "class_number": "CH2024250100002",
+        "course_code": "CSE3012",
+        "course_name": "Computer Networks",
+        "course_type": "Theory",
+        "course_type_code": "TH",
+        "course_slot": "B1",
+        "faculty": "Dr. Sample Faculty B",
+        "attended_classes": "24",
+        "total_classes": "29",
+        "attendance_percentage": "82",
+        "attendance_between_percentage": "80-90",
+        "debar_status": "Not Debarred",
+        "course_id": "CSE3012-B1-TH"
+      },
+      {
+        "class_number": "CH2024250100003",
+        "course_code": "CSE3013",
+        "course_name": "Machine Learning",
+        "course_type": "Theory",
+        "course_type_code": "TH",
+        "course_slot": "C1",
+        "faculty": "Dr. Sample Faculty C",
+        "attended_classes": "20",
+        "total_classes": "27",
+        "attendance_percentage": "74",
+        "attendance_between_percentage": "70-80",
+        "debar_status": "Not Debarred",
+        "course_id": "CSE3013-C1-TH"
+      }
+    ],
+    "exam_schedule": [
+      {
+        "exam_type": "CAT-1",
+        "subjects": [
+          {
+            "serial_number": "1",
+            "course_code": "CSE3011",
+            "course_name": "Design and Analysis of Algorithms",
+            "course_type": "Theory",
+            "course_id": "CSE3011-A1-TH",
+            "slot": "A1",
+            "exam_date": "10-Sep-2026",
+            "exam_session": "FN",
+            "reporting_time": "09:00",
+            "exam_time": "09:30 - 11:00",
+            "venue": "AB1-201",
+            "seat_location": "Ground Floor",
+            "seat_number": "12"
+          },
+          {
+            "serial_number": "2",
+            "course_code": "CSE3012",
+            "course_name": "Computer Networks",
+            "course_type": "Theory",
+            "course_id": "CSE3012-B1-TH",
+            "slot": "B1",
+            "exam_date": "12-Sep-2026",
+            "exam_session": "FN",
+            "reporting_time": "09:00",
+            "exam_time": "09:30 - 11:00",
+            "venue": "AB1-305",
+            "seat_location": "First Floor",
+            "seat_number": "27"
+          }
+        ]
+      },
+      {
+        "exam_type": "Final Assessment Test",
+        "subjects": [
+          {
+            "serial_number": "1",
+            "course_code": "CSE3013",
+            "course_name": "Machine Learning",
+            "course_type": "Theory",
+            "course_id": "CSE3013-C1-TH",
+            "slot": "C1",
+            "exam_date": "20-Nov-2026",
+            "exam_session": "AN",
+            "reporting_time": "13:30",
+            "exam_time": "14:00 - 17:00",
+            "venue": "AB2-108",
+            "seat_location": "Ground Floor",
+            "seat_number": "5"
+          }
+        ]
+      }
+    ],
+    "marks": [
+      {
+        "serial_number": "1",
+        "course_code": "CSE3011",
+        "course_title": "Design and Analysis of Algorithms",
+        "course_type": "Theory",
+        "faculty": "Dr. Sample Faculty A",
+        "slot": "A1",
+        "details": [
+          {
+            "serial_number": "1",
+            "mark_title": "Digital Assignment-1",
+            "max_mark": "10",
+            "weightage": "10",
+            "status": "Present",
+            "scored_mark": "9",
+            "weightage_mark": "9.00",
+            "remark": "Good"
+          },
+          {
+            "serial_number": "2",
+            "mark_title": "CAT-1",
+            "max_mark": "50",
+            "weightage": "15",
+            "status": "Present",
+            "scored_mark": "42",
+            "weightage_mark": "12.60",
+            "remark": "-"
+          }
+        ]
+      },
+      {
+        "serial_number": "2",
+        "course_code": "CSE3012",
+        "course_title": "Computer Networks",
+        "course_type": "Theory",
+        "faculty": "Dr. Sample Faculty B",
+        "slot": "B1",
+        "details": [
+          {
+            "serial_number": "1",
+            "mark_title": "Quiz-1",
+            "max_mark": "10",
+            "weightage": "10",
+            "status": "Present",
+            "scored_mark": "8",
+            "weightage_mark": "8.00",
+            "remark": "-"
+          }
+        ]
+      }
+    ]
+  },
+  "detailed_attendance": [
+    {
+      "serial": "1",
+      "date": "15-Jul-2026",
+      "slot": "A1",
+      "day_time": "Monday (09:00)",
+      "status": "Present",
+      "remark": "-"
+    },
+    {
+      "serial": "2",
+      "date": "17-Jul-2026",
+      "slot": "A1",
+      "day_time": "Wednesday (09:00)",
+      "status": "Present",
+      "remark": "-"
+    },
+    {
+      "serial": "3",
+      "date": "22-Jul-2026",
+      "slot": "A1",
+      "day_time": "Monday (09:00)",
+      "status": "Absent",
+      "remark": "On Duty"
+    }
+  ],
+  "biometric": [
+    {
+      "in_time": "08:42 AM",
+      "location": "AB1 Main Gate"
+    },
+    {
+      "in_time": "01:15 PM",
+      "location": "Library Entrance"
+    }
+  ],
+  "pending_payments": [
+    {
+      "s_no": "1",
+      "fprefno": "DEMOREF001",
+      "fees_heads": "Semester Tuition Fee",
+      "end_date": "31-Aug-2026",
+      "amount": "95000",
+      "fine": "0",
+      "total_amount": "95000",
+      "payment_status": "Pending"
+    }
+  ],
+  "payment_receipts": [
+    {
+      "receipt_number": "1",
+      "date": "12-Jan-2026",
+      "amount": "95000",
+      "campus_code": "VITAP",
+      "payment_status": "Success",
+      "receipt_no": "DEMO-RCPT-2026-001"
+    },
+    {
+      "receipt_number": "2",
+      "date": "10-Jul-2025",
+      "amount": "95000",
+      "campus_code": "VITAP",
+      "payment_status": "Success",
+      "receipt_no": "DEMO-RCPT-2025-014"
+    }
+  ],
+  "general_outing_reports": [
+    {
+      "serial": "1",
+      "registration_number": "21BCE7625",
+      "place_of_visit": "Vijayawada",
+      "purpose_of_visit": "Shopping",
+      "from_date": "05-Jul-2026",
+      "from_time": "09:00",
+      "to_date": "05-Jul-2026",
+      "to_time": "18:00",
+      "status": "Approved",
+      "can_download": false,
+      "leave_id": "DEMO-GEN-001"
+    }
+  ],
+  "weekend_outing_reports": [
+    {
+      "serial": "1",
+      "registration_number": "21BCE7625",
+      "hostel_block": "D-Block",
+      "room_number": "512",
+      "place_of_visit": "Guntur",
+      "purpose_of_visit": "Home Visit",
+      "time": "08:00",
+      "contact_number": "90000 00000",
+      "parent_contact_number": "90000 11111",
+      "date": "2026-07-11T00:00:00.000",
+      "booking_id": "DEMO-WKND-001",
+      "status": "Approved",
+      "can_download": false
+    }
+  ],
+  "faculty_details": {
+    "name": "Dr. Sample Faculty A",
+    "designation": "Assistant Professor Senior",
+    "department": "Computer Science and Engineering",
+    "schoolCentre": "School of Computer Science and Engineering",
+    "email": "sample.facultya@vitap.ac.in",
+    "cabinNumber": "AB-1, 410-B",
+    "officeHours": [
+      {
+        "day": "Monday",
+        "timings": "02:00 PM - 04:00 PM"
+      },
+      {
+        "day": "Wednesday",
+        "timings": "02:00 PM - 04:00 PM"
+      }
+    ]
+  },
+  "courses": {
+    "courses": [
+      {
+        "value": "CSE3011-A1-TH",
+        "label": "CSE3011 - Design and Analysis of Algorithms (Theory)",
+        "course_code": "CSE3011",
+        "course_title": "Design and Analysis of Algorithms",
+        "course_type": "Theory"
+      },
+      {
+        "value": "CSE3012-B1-TH",
+        "label": "CSE3012 - Computer Networks (Theory)",
+        "course_code": "CSE3012",
+        "course_title": "Computer Networks",
+        "course_type": "Theory"
+      }
+    ]
+  },
+  "slots": {
+    "slots": [
+      {
+        "value": "A1",
+        "label": "A1"
+      },
+      {
+        "value": "B1",
+        "label": "B1"
+      }
+    ],
+    "class_entries": [
+      {
+        "sl_no": 1,
+        "class_group": "CSE3011-A1",
+        "course_code": "CSE3011",
+        "course_title": "Design and Analysis of Algorithms",
+        "course_type": "Theory",
+        "class_id": "CSE3011-A1-TH",
+        "slot": "A1",
+        "faculty": "Dr. Sample Faculty A",
+        "semester_id": "DEMOSEM2526",
+        "erp_id": "DEMO-ERP-001"
+      }
+    ]
+  },
+  "course_detail": {
+    "course_info": {
+      "class_group": "CSE3011-A1",
+      "course_code": "CSE3011",
+      "course_title": "Design and Analysis of Algorithms",
+      "course_type": "Theory",
+      "class_id": "CSE3011-A1-TH",
+      "slot": "A1",
+      "faculty": "Dr. Sample Faculty A",
+      "course_id": "CSE3011"
+    },
+    "semester_id": "DEMOSEM2526",
+    "download_all_path": null,
+    "download_general_materials_path": null,
+    "syllabus_download_path": null,
+    "course_plan_download_path": null,
+    "lectures": [
+      {
+        "sl_no": 1,
+        "date": "15-Jul-2026",
+        "formatted_date": "15 Jul 2026",
+        "day": "Monday",
+        "topic": "Introduction to Algorithm Analysis and Asymptotic Notation",
+        "reference_materials": []
+      },
+      {
+        "sl_no": 2,
+        "date": "17-Jul-2026",
+        "formatted_date": "17 Jul 2026",
+        "day": "Wednesday",
+        "topic": "Divide and Conquer: Merge Sort and Quick Sort",
+        "reference_materials": []
+      }
+    ]
+  },
+  "digital_assignments": [
+    {
+      "serial_number": "1",
+      "class_id": "CSE3011-A1-TH",
+      "course_code": "CSE3011",
+      "course_title": "Design and Analysis of Algorithms",
+      "course_type": "Theory",
+      "faculty": "Dr. Sample Faculty A",
+      "details": [
+        {
+          "serial_number": "1",
+          "assignment_title": "Digital Assignment-1",
+          "max_assignment_mark": "10",
+          "assignment_weightage_mark": "10",
+          "due_date": "25-Jul-2026",
+          "can_qp_download": false,
+          "qp_download_url": "",
+          "submission_status": "Submitted",
+          "can_update": false,
+          "mcode": "DEMO-MCODE-001",
+          "can_da_download": false,
+          "da_download_url": ""
+        },
+        {
+          "serial_number": "2",
+          "assignment_title": "Digital Assignment-2",
+          "max_assignment_mark": "10",
+          "assignment_weightage_mark": "10",
+          "due_date": "12-Aug-2026",
+          "can_qp_download": false,
+          "qp_download_url": "",
+          "submission_status": "Pending",
+          "can_update": false,
+          "mcode": "DEMO-MCODE-002",
+          "can_da_download": false,
+          "da_download_url": ""
+        }
+      ]
+    }
+  ]
+}

--- a/lib/core/error/exceptions.dart
+++ b/lib/core/error/exceptions.dart
@@ -203,6 +203,20 @@ class VtopException implements Exception {
       isResponseReadError;
 }
 
+/// Exception thrown when a live VTOP operation is attempted while the app is
+/// running in demo mode. Demo sessions never contact VTOP; this acts as a
+/// safety net so any un-gated code path fails fast with a friendly message
+/// instead of trying to authenticate with placeholder demo credentials.
+class DemoModeException implements Exception {
+  final String message;
+  const DemoModeException([
+    this.message = 'This feature is not available in the demo account.',
+  ]);
+
+  @override
+  String toString() => 'DemoModeException: $message';
+}
+
 /// Exception for general app errors
 class AppException implements Exception {
   final String message;

--- a/lib/core/providers/current_user.dart
+++ b/lib/core/providers/current_user.dart
@@ -4,6 +4,7 @@ import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/models/semester_cache.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/user_preferences_notifier.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/core/services/notification_service.dart';
 import 'package:vit_ap_student_app/core/services/secure_store_service.dart';
 import 'package:vit_ap_student_app/init_dependencies.dart';
@@ -79,6 +80,10 @@ class CurrentUserNotifier extends _$CurrentUserNotifier {
       // Clear user state and storage
       state = null;
       _clearUserDataObjectBox();
+
+      // Exit demo mode (no-op for normal accounts) so a subsequent real login
+      // is not treated as a demo session.
+      await DemoService.instance.setDemoMode(false);
 
       // Remove credentials
       await serviceLocator.get<SecureStorageService>().clearCredentials();

--- a/lib/core/services/demo_service.dart
+++ b/lib/core/services/demo_service.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vit_ap_student_app/core/models/credentials.dart';
+import 'package:vit_ap_student_app/core/models/user.dart';
+import 'package:vit_ap_student_app/features/attendance/model/attendance_detail.dart';
+import 'package:vit_ap_student_app/features/course_page/model/course_page_detail.dart';
+import 'package:vit_ap_student_app/features/course_page/model/courses_response.dart';
+import 'package:vit_ap_student_app/features/course_page/model/slots_response.dart';
+import 'package:vit_ap_student_app/features/digital_assignment/model/digital_assignment_model.dart';
+import 'package:vit_ap_student_app/features/home/model/biometric.dart';
+import 'package:vit_ap_student_app/features/home/model/general_outing_report.dart';
+import 'package:vit_ap_student_app/features/home/model/payment_receipt.dart';
+import 'package:vit_ap_student_app/features/home/model/pending_payment.dart';
+import 'package:vit_ap_student_app/features/home/model/weekend_outing_report.dart';
+import 'package:vit_ap_student_app/src/rust/api/vtop/types/faculty.dart';
+
+/// Provides the "Demo Login" experience used for App Store review and product
+/// demonstrations.
+///
+/// When the predefined demo credentials are entered on the login screen, the
+/// app bypasses the entire VTOP authentication flow (including OTP) and seeds
+/// itself from a locally bundled, fully sanitized dataset
+/// (`assets/demo/demo_dataset.json`). No real student data is ever exposed and
+/// no network request reaches VTOP while demo mode is active.
+///
+/// [isDemoMode] is cached in memory (so it can be read synchronously from hot
+/// paths like [VtopClientService.getClient] and feature view models) and
+/// persisted in [SharedPreferences] so the demo survives app restarts. Call
+/// [init] once during dependency setup to hydrate the cached flag.
+class DemoService {
+  DemoService._();
+
+  static final DemoService instance = DemoService._();
+
+  /// Registration number reviewers enter to trigger the demo experience.
+  static const String demoRegistrationNumber = '21BCE7625';
+
+  /// Password reviewers enter to trigger the demo experience.
+  static const String demoPassword = 'Demo@1234';
+
+  /// Placeholder semester id stored alongside the demo credentials.
+  static const String demoSemesterId = 'DEMOSEM2526';
+
+  static const String _prefsKey = 'is_demo_mode';
+  static const String _assetPath = 'assets/demo/demo_dataset.json';
+
+  bool _isDemoMode = false;
+  Map<String, dynamic>? _cache;
+
+  /// Whether the app is currently running as the demo account.
+  static bool get isDemoMode => instance._isDemoMode;
+
+  /// Hydrate the cached demo flag from persistent storage. Safe to call once
+  /// during app initialization.
+  static Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    instance._isDemoMode = prefs.getBool(_prefsKey) ?? false;
+  }
+
+  /// Returns true when the supplied credentials match the demo account.
+  bool isDemoCredentials(String username, String password) =>
+      username.trim().toUpperCase() == demoRegistrationNumber &&
+      password.trim() == demoPassword;
+
+  /// Credentials persisted for the demo session so the rest of the app treats
+  /// the demo user like any other logged-in user.
+  Credentials get credentials => Credentials(
+        registrationNumber: demoRegistrationNumber,
+        password: demoPassword,
+        semSubId: demoSemesterId,
+      );
+
+  /// Enable or disable demo mode, updating both the cached flag and persistent
+  /// storage. Disabling also drops the in-memory dataset cache.
+  Future<void> setDemoMode(bool value) async {
+    _isDemoMode = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_prefsKey, value);
+    if (!value) _cache = null;
+  }
+
+  Future<Map<String, dynamic>> _dataset() async {
+    _cache ??= json.decode(await rootBundle.loadString(_assetPath))
+        as Map<String, dynamic>;
+    return _cache!;
+  }
+
+  Future<T> _section<T>(
+    String key,
+    T Function(Object? value) parse,
+  ) async {
+    final data = await _dataset();
+    return parse(data[key]);
+  }
+
+  // --- Primary data (seeded into the User at login) -------------------------
+
+  /// The full demo [User] used to seed local storage at login. Screens read
+  /// profile, timetable, attendance, marks and exam schedule from this.
+  Future<User> loadDemoUser() =>
+      _section('user', (v) => User.fromJson(v as Map<String, dynamic>));
+
+  // --- Secondary read-only feature data -------------------------------------
+
+  Future<List<AttendanceDetail>> detailedAttendance() => _section(
+        'detailed_attendance',
+        (v) => (v as List<dynamic>)
+            .map((e) => AttendanceDetail.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  Future<List<Biometric>> biometric() => _section(
+        'biometric',
+        (v) => (v as List<dynamic>)
+            .map((e) => Biometric.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  Future<List<PendingPayment>> pendingPayments() => _section(
+        'pending_payments',
+        (v) => (v as List<dynamic>)
+            .map((e) => PendingPayment.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  Future<List<PaymentReceipt>> paymentReceipts() => _section(
+        'payment_receipts',
+        (v) => (v as List<dynamic>)
+            .map((e) => PaymentReceipt.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  Future<List<GeneralOutingReport>> generalOutingReports() => _section(
+        'general_outing_reports',
+        (v) => (v as List<dynamic>)
+            .map((e) => GeneralOutingReport.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  Future<List<WeekendOutingReport>> weekendOutingReports() => _section(
+        'weekend_outing_reports',
+        (v) => (v as List<dynamic>)
+            .map((e) => WeekendOutingReport.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  Future<FacultyDetails> facultyDetails() => _section(
+        'faculty_details',
+        (v) => FacultyDetails.fromJson(v as Map<String, dynamic>),
+      );
+
+  Future<CoursesResponseModel> courses() => _section(
+        'courses',
+        (v) => CoursesResponseModel.fromJson(v as Map<String, dynamic>),
+      );
+
+  Future<SlotsResponseModel> slots() => _section(
+        'slots',
+        (v) => SlotsResponseModel.fromJson(v as Map<String, dynamic>),
+      );
+
+  Future<CoursePageDetailModel> courseDetail() => _section(
+        'course_detail',
+        (v) => CoursePageDetailModel.fromJson(v as Map<String, dynamic>),
+      );
+
+  Future<List<DigitalAssignment>> digitalAssignments() => _section(
+        'digital_assignments',
+        (v) => (v as List<dynamic>)
+            .map((e) => DigitalAssignment.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}

--- a/lib/core/services/vtop_service.dart
+++ b/lib/core/services/vtop_service.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
+import 'package:vit_ap_student_app/core/error/exceptions.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/src/rust/api/vtop/vtop_client.dart';
 import 'package:vit_ap_student_app/src/rust/api/vtop/vtop_errors.dart';
 import 'package:vit_ap_student_app/src/rust/api/vtop_get_client.dart';
@@ -68,6 +70,14 @@ class VtopClientService {
     required String username,
     required String password,
   }) async {
+    // Safety net: the demo account must never contact VTOP. Feature view models
+    // short-circuit to bundled sample data before reaching this point; if any
+    // path slips through, fail fast with a friendly message instead of trying
+    // to authenticate with placeholder demo credentials.
+    if (DemoService.isDemoMode) {
+      throw const DemoModeException();
+    }
+
     // If OTP is pending, wait for resolution instead of returning partial client
     if (_otpPending && _otpCompleter != null) {
       await _otpCompleter!.future;

--- a/lib/features/account/view/pages/account_page.dart
+++ b/lib/features/account/view/pages/account_page.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
 import 'package:vit_ap_student_app/core/providers/user_preferences_notifier.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/core/utils/launch_web.dart';
 import 'package:vit_ap_student_app/core/utils/share_utils.dart';
 import 'package:vit_ap_student_app/core/utils/show_snackbar.dart';
@@ -179,37 +180,43 @@ class _AccountPageState extends ConsumerState<AccountPage> {
                       ),
                       onTap: () => _navigateToProfile(user),
                     ),
-                    SettingTile(
-                      isFirst: false,
-                      isLast: false,
-                      title: 'Manage Credentials',
-                      leadingIcon: const Icon(Iconsax.lock_1_copy),
-                      trailingIcon: Icon(
-                        Icons.arrow_forward_rounded,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                      onTap: () async {
-                        await AnalyticsService.logEvent(
-                          'manage_credentials_navigation',
-                          {
-                            'from': 'AccountPage',
-                            'timestamp': DateTime.now().toIso8601String(),
-                          },
-                        );
-                        final result = await Navigator.push<bool>(
-                          context,
-                          MaterialPageRoute<bool>(
-                            builder: (builder) => const ManageCredentialsPage(),
-                          ),
-                        );
-                        if (result == true) {
+                    // Managing VTOP credentials is meaningless for the demo
+                    // account, so the entry point is hidden in demo mode.
+                    if (!DemoService.isDemoMode)
+                      SettingTile(
+                        isFirst: false,
+                        isLast: false,
+                        title: 'Manage Credentials',
+                        leadingIcon: const Icon(Iconsax.lock_1_copy),
+                        trailingIcon: Icon(
+                          Icons.arrow_forward_rounded,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        onTap: () async {
                           await AnalyticsService.logEvent(
-                            'credentials_updated_sync_triggered',
+                            'manage_credentials_navigation',
+                            {
+                              'from': 'AccountPage',
+                              'timestamp': DateTime.now().toIso8601String(),
+                            },
                           );
-                          await ref.read(accountViewModelProvider.notifier).sync();
-                        }
-                      },
-                    ),
+                          final result = await Navigator.push<bool>(
+                            context,
+                            MaterialPageRoute<bool>(
+                              builder: (builder) =>
+                                  const ManageCredentialsPage(),
+                            ),
+                          );
+                          if (result == true) {
+                            await AnalyticsService.logEvent(
+                              'credentials_updated_sync_triggered',
+                            );
+                            await ref
+                                .read(accountViewModelProvider.notifier)
+                                .sync();
+                          }
+                        },
+                      ),
                     SettingTile(
                       isFirst: false,
                       isLast: false,

--- a/lib/features/account/viewmodel/account_viewmodel.dart
+++ b/lib/features/account/viewmodel/account_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/account/repository/account_remote_repository.dart';
 
 part 'account_viewmodel.g.dart';
@@ -21,6 +22,16 @@ class AccountViewModel extends _$AccountViewModel {
 
   Future<void> sync() async {
     state = const AsyncValue.loading();
+
+    // Demo mode: re-affirm the seeded demo user without contacting VTOP.
+    if (DemoService.isDemoMode) {
+      final demoUser = ref.read(currentUserProvider);
+      state = demoUser != null
+          ? AsyncValue.data(demoUser)
+          : AsyncValue.data(await DemoService.instance.loadDemoUser());
+      return;
+    }
+
     final User? user = ref.read(currentUserProvider);
     final userNotifier = ref.read(currentUserProvider.notifier);
     final Credentials? credentials = await userNotifier.getSavedCredentials();

--- a/lib/features/attendance/viewmodel/attendance_viewmodel.dart
+++ b/lib/features/attendance/viewmodel/attendance_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/models/attendance.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/attendance/repository/attendance_remote_repository.dart';
 
 part 'attendance_viewmodel.g.dart';
@@ -21,6 +22,14 @@ class AttendanceViewMode extends _$AttendanceViewMode {
   }
 
   Future<void> refreshAttendance({bool silentRefresh = false}) async {
+    // Demo mode: serve the attendance seeded into the user at login; never
+    // contact VTOP.
+    if (DemoService.isDemoMode) {
+      final demoUser = ref.read(currentUserProvider);
+      state = AsyncValue.data(demoUser?.attendance.toList() ?? []);
+      return;
+    }
+
     if (!silentRefresh) {
       state = const AsyncValue.loading();
     }

--- a/lib/features/attendance/viewmodel/detailed_attendance_viewmodel.dart
+++ b/lib/features/attendance/viewmodel/detailed_attendance_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/attendance/model/attendance_detail.dart';
 import 'package:vit_ap_student_app/features/attendance/repository/attendance_remote_repository.dart';
 
@@ -22,6 +23,15 @@ class DetailedAttendanceViewmodel extends _$DetailedAttendanceViewmodel {
     required String courseType,
   }) async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample detailed attendance.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(
+        await DemoService.instance.detailedAttendance(),
+      );
+      return;
+    }
+
     final userNotifier = ref.read(currentUserProvider.notifier);
     final Credentials? credentials = await userNotifier.getSavedCredentials();
 

--- a/lib/features/auth/view/pages/login_page.dart
+++ b/lib/features/auth/view/pages/login_page.dart
@@ -3,13 +3,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:vit_ap_student_app/core/common/widget/auth_field.dart';
+import 'package:vit_ap_student_app/core/common/widget/bottom_navigation_bar.dart';
 import 'package:vit_ap_student_app/core/common/widget/loader.dart';
 import 'package:vit_ap_student_app/core/network/connection_checker.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/core/utils/launch_web.dart';
 import 'package:vit_ap_student_app/core/utils/show_snackbar.dart';
 import 'package:vit_ap_student_app/core/utils/theme_switch_button.dart';
 import 'package:vit_ap_student_app/features/auth/view/pages/semester_selection_page.dart';
+import 'package:vit_ap_student_app/features/auth/viewmodel/auth_viewmodel.dart';
 import 'package:vit_ap_student_app/features/auth/viewmodel/semester_viewmodel.dart';
 import 'package:wiredash/wiredash.dart';
 
@@ -44,7 +47,39 @@ class LoginPageState extends ConsumerState<LoginPage> {
     super.dispose();
   }
 
+  Future<void> _loginDemo() async {
+    await AnalyticsService.logButtonTap('demo_login', 'login_page');
+    await ref.read(authViewModelProvider.notifier).loginDemoUser();
+    if (!mounted) return;
+
+    ref.read(authViewModelProvider)?.when(
+          data: (_) {
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute<void>(
+                builder: (context) => const BottomNavBar(),
+              ),
+              (_) => false,
+            );
+          },
+          error: (error, _) {
+            showSnackBar(context, error.toString(), SnackBarType.error);
+          },
+          loading: () {},
+        );
+  }
+
   Future<void> _fetchSemestersAndNavigate() async {
+    // Demo account: bypass VTOP entirely (no network, no OTP, no semester
+    // selection) and seed the app from the bundled sample dataset.
+    if (DemoService.instance.isDemoCredentials(
+      usernameController.text,
+      passwordController.text,
+    )) {
+      await _loginDemo();
+      return;
+    }
+
     final connectivityResult = await ConnectionCheckerImpl(
       InternetConnection(),
     ).isConnected;
@@ -86,8 +121,11 @@ class LoginPageState extends ConsumerState<LoginPage> {
   @override
   Widget build(BuildContext context) {
     final isLoading = ref.watch(
-      semesterViewModelProvider.select((val) => val?.isLoading == true),
-    );
+          semesterViewModelProvider.select((val) => val?.isLoading == true),
+        ) ||
+        ref.watch(
+          authViewModelProvider.select((val) => val?.isLoading == true),
+        );
 
     ref.listen(semesterViewModelProvider, (previous, next) {
       // Only navigate if this is the initial fetch (previous was null or loading)

--- a/lib/features/auth/viewmodel/auth_viewmodel.dart
+++ b/lib/features/auth/viewmodel/auth_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/auth/repository/auth_remote_repository.dart';
 
 part 'auth_viewmodel.g.dart';
@@ -19,6 +20,42 @@ class AuthViewModel extends _$AuthViewModel {
     _authRemoteRepository = ref.watch(authRemoteRepositoryProvider);
     _currentUserNotifier = ref.watch(currentUserProvider.notifier);
     return null;
+  }
+
+  /// Logs in the bundled demo account for App Store review / demos.
+  ///
+  /// Bypasses the entire VTOP flow (no credential check, no semester fetch, no
+  /// OTP) and seeds local storage from [DemoService]'s sanitized dataset.
+  Future<void> loginDemoUser() async {
+    state = const AsyncValue.loading();
+
+    await AnalyticsService.logEvent('login_attempt', {
+      'method': 'demo',
+    });
+
+    try {
+      final user = await DemoService.instance.loadDemoUser();
+      final credentials = DemoService.instance.credentials;
+
+      await DemoService.instance.setDemoMode(true);
+      await _currentUserNotifier.loginUser(user, credentials);
+
+      await AnalyticsService.logLogin('demo');
+      await AnalyticsService.logEvent('login_success', {
+        'method': 'demo',
+      });
+
+      state = AsyncValue.data(user);
+    } catch (e) {
+      // Roll back the flag so the app doesn't get stuck in a broken demo state.
+      await DemoService.instance.setDemoMode(false);
+      await AnalyticsService.logError('auth_error', 'Demo login failed: $e',
+          location: 'loginDemoUser');
+      state = AsyncValue.error(
+        'Failed to start the demo. Please try again.',
+        StackTrace.current,
+      );
+    }
   }
 
   Future<void> loginUser({

--- a/lib/features/course_page/viewmodel/course_detail_viewmodel.dart
+++ b/lib/features/course_page/viewmodel/course_detail_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/course_page/model/course_page_detail.dart';
 import 'package:vit_ap_student_app/features/course_page/repository/course_page_remote_repository.dart';
 
@@ -22,6 +23,13 @@ class CourseDetailViewmodel extends _$CourseDetailViewmodel {
     required String classId,
   }) async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample course detail.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.courseDetail());
+      return;
+    }
+
     final userNotifier = ref.read(currentUserProvider.notifier);
     final Credentials? credentials = await userNotifier.getSavedCredentials();
 

--- a/lib/features/course_page/viewmodel/courses_viewmodel.dart
+++ b/lib/features/course_page/viewmodel/courses_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/course_page/model/courses_response.dart';
 import 'package:vit_ap_student_app/features/course_page/repository/course_page_remote_repository.dart';
 
@@ -19,6 +20,13 @@ class CoursesViewmodel extends _$CoursesViewmodel {
 
   Future<void> fetchCourses() async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample course list.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.courses());
+      return;
+    }
+
     final userNotifier = ref.read(currentUserProvider.notifier);
     final Credentials? credentials = await userNotifier.getSavedCredentials();
 

--- a/lib/features/course_page/viewmodel/slots_viewmodel.dart
+++ b/lib/features/course_page/viewmodel/slots_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/course_page/model/slots_response.dart';
 import 'package:vit_ap_student_app/features/course_page/repository/course_page_remote_repository.dart';
 
@@ -19,6 +20,13 @@ class SlotsViewmodel extends _$SlotsViewmodel {
 
   Future<void> fetchSlots({required String classId}) async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample slots.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.slots());
+      return;
+    }
+
     final userNotifier = ref.read(currentUserProvider.notifier);
     final Credentials? credentials = await userNotifier.getSavedCredentials();
 

--- a/lib/features/digital_assignment/view/widgets/assignment_tile.dart
+++ b/lib/features/digital_assignment/view/widgets/assignment_tile.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_flutter/iconsax_flutter.dart';
 import 'package:vit_ap_student_app/core/constants/app_constants.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/core/services/notification_service.dart';
 import 'package:vit_ap_student_app/core/utils/file_saver.dart';
 import 'package:vit_ap_student_app/core/utils/file_type_detector.dart';
@@ -139,14 +140,18 @@ class _AssignmentTileState extends ConsumerState<AssignmentTile> {
             spacing: 8,
             runSpacing: 8,
             children: [
-              // Upload / Update button
-              if (_status == SubmissionState.pending)
+              // Upload / Update button. Uploading is a write action to VTOP,
+              // hidden for the demo account.
+              if (_status == SubmissionState.pending &&
+                  !DemoService.isDemoMode)
                 AssignmentActionButton(
                   icon: Iconsax.document_upload,
                   label: 'Upload',
                   onPressed: () => _pickAndUpload(context, widget.detail.mcode),
                 ),
-              if (_status == SubmissionState.submitted && detail.canUpdate)
+              if (_status == SubmissionState.submitted &&
+                  detail.canUpdate &&
+                  !DemoService.isDemoMode)
                 AssignmentActionButton(
                   icon: Iconsax.refresh_circle,
                   label: 'Update',

--- a/lib/features/digital_assignment/viewmodel/digital_assignment_viewmodel.dart
+++ b/lib/features/digital_assignment/viewmodel/digital_assignment_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/digital_assignment/model/digital_assignment_model.dart';
 import 'package:vit_ap_student_app/features/digital_assignment/repository/digital_assignment_remote_repository.dart';
 
@@ -21,6 +22,13 @@ class DigitalAssignmentViewModel extends _$DigitalAssignmentViewModel {
     if (!silentRefresh) {
       state = const AsyncValue.loading();
     }
+
+    // Demo mode: serve bundled sample digital assignments.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.digitalAssignments());
+      return;
+    }
+
     final userNotifier = ref.read(currentUserProvider.notifier);
     final Credentials? credentials = await userNotifier.getSavedCredentials();
     if (credentials == null) {

--- a/lib/features/home/view/pages/outing/general_outing_tab.dart
+++ b/lib/features/home/view/pages/outing/general_outing_tab.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:vit_ap_student_app/core/common/widget/loader.dart';
 import 'package:vit_ap_student_app/core/common/widgets/common_date_picker.dart';
 import 'package:vit_ap_student_app/core/common/widgets/common_time_picker.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/core/utils/show_snackbar.dart';
 import 'package:vit_ap_student_app/features/home/view/pages/outing/general_outing_history_page.dart';
 import 'package:vit_ap_student_app/features/home/viewmodel/outing_submission_viewmodel.dart';
@@ -221,25 +222,29 @@ class _GeneralOutingTabState extends ConsumerState<GeneralOutingTab> {
                     ),
                   ),
                 ),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: isLoading
-                      ? const Loader()
-                      : TextButton.icon(
-                          icon: const Icon(
-                            Icons.arrow_forward_sharp,
-                            color: Colors.blue,
-                          ),
-                          iconAlignment: IconAlignment.end,
-                          onPressed: _submitForm,
-                          label: const Text(
-                            'Apply',
-                            style: TextStyle(
+                // Submitting an outing is a write action to VTOP, disabled for
+                // the demo account. History remains viewable via the button on
+                // the left.
+                if (!DemoService.isDemoMode)
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: isLoading
+                        ? const Loader()
+                        : TextButton.icon(
+                            icon: const Icon(
+                              Icons.arrow_forward_sharp,
                               color: Colors.blue,
                             ),
+                            iconAlignment: IconAlignment.end,
+                            onPressed: _submitForm,
+                            label: const Text(
+                              'Apply',
+                              style: TextStyle(
+                                color: Colors.blue,
+                              ),
+                            ),
                           ),
-                        ),
-                ),
+                  ),
               ],
             ),
           ],

--- a/lib/features/home/view/pages/outing/weekend_outing_tab.dart
+++ b/lib/features/home/view/pages/outing/weekend_outing_tab.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/common/widget/loader.dart';
 import 'package:vit_ap_student_app/core/common/widgets/common_date_picker.dart';
 import 'package:vit_ap_student_app/core/constants/app_constants.dart';
 import 'package:vit_ap_student_app/core/providers/user_preferences_notifier.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/core/utils/show_snackbar.dart';
 import 'package:vit_ap_student_app/features/home/view/pages/outing/weekend_outing_history_page.dart';
 import 'package:vit_ap_student_app/features/home/viewmodel/outing_submission_viewmodel.dart';
@@ -388,25 +389,29 @@ class _WeekendOutingTabState extends ConsumerState<WeekendOutingTab> {
                     ),
                   ),
                 ),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: isLoading
-                      ? const Loader()
-                      : TextButton.icon(
-                          icon: const Icon(
-                            Icons.arrow_forward_sharp,
-                            color: Colors.blue,
-                          ),
-                          iconAlignment: IconAlignment.end,
-                          onPressed: _submitWeekendOuting,
-                          label: const Text(
-                            'Apply',
-                            style: TextStyle(
+                // Submitting an outing is a write action to VTOP, disabled for
+                // the demo account. History remains viewable via the button on
+                // the left.
+                if (!DemoService.isDemoMode)
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: isLoading
+                        ? const Loader()
+                        : TextButton.icon(
+                            icon: const Icon(
+                              Icons.arrow_forward_sharp,
                               color: Colors.blue,
                             ),
+                            iconAlignment: IconAlignment.end,
+                            onPressed: _submitWeekendOuting,
+                            label: const Text(
+                              'Apply',
+                              style: TextStyle(
+                                color: Colors.blue,
+                              ),
+                            ),
                           ),
-                        ),
-                ),
+                  ),
               ],
             ),
           ],

--- a/lib/features/home/viewmodel/biometric_viewmodel.dart
+++ b/lib/features/home/viewmodel/biometric_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/home/model/biometric.dart';
 import 'package:vit_ap_student_app/features/home/repository/home_remote_repository.dart';
 
@@ -19,6 +20,13 @@ class BiometricViewModel extends _$BiometricViewModel {
 
   Future<void> fetchBiometric(String date) async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample biometric log.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.biometric());
+      return;
+    }
+
     final credentials = await ref
         .read(currentUserProvider.notifier)
         .getSavedCredentials();

--- a/lib/features/home/viewmodel/exam_schedule_viewmodel.dart
+++ b/lib/features/home/viewmodel/exam_schedule_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/models/exam_schedule.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/home/repository/home_remote_repository.dart';
 
 part 'exam_schedule_viewmodel.g.dart';
@@ -21,6 +22,13 @@ class ExamScheduleViewModel extends _$ExamScheduleViewModel {
   }
 
   Future<void> refreshExamSchedule() async {
+    // Demo mode: serve the exam schedule seeded into the user at login.
+    if (DemoService.isDemoMode) {
+      final demoUser = ref.read(currentUserProvider);
+      state = AsyncValue.data(demoUser?.examSchedule.toList() ?? []);
+      return;
+    }
+
     state = const AsyncValue.loading();
     final User? user = ref.read(currentUserProvider);
     final userNotifier = ref.read(currentUserProvider.notifier);

--- a/lib/features/home/viewmodel/faculty_viewmodel.dart
+++ b/lib/features/home/viewmodel/faculty_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/home/model/faculty.dart';
 import 'package:vit_ap_student_app/features/home/repository/faculty_repository.dart';
 import 'package:vit_ap_student_app/src/rust/api/vtop/types/faculty.dart';
@@ -51,6 +52,12 @@ class FacultyDetailsViewModel extends _$FacultyDetailsViewModel {
 
   Future<void> fetchDetails(String empId) async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample faculty details.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.facultyDetails());
+      return;
+    }
 
     final credentials = await ref
         .read(currentUserProvider.notifier)

--- a/lib/features/home/viewmodel/marks_viewmodel.dart
+++ b/lib/features/home/viewmodel/marks_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/models/mark.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/home/repository/home_remote_repository.dart';
 
 part 'marks_viewmodel.g.dart';
@@ -21,6 +22,13 @@ class MarksViewModel extends _$MarksViewModel {
   }
 
   Future<void> refreshMarks() async {
+    // Demo mode: serve the marks seeded into the user at login.
+    if (DemoService.isDemoMode) {
+      final demoUser = ref.read(currentUserProvider);
+      state = AsyncValue.data(demoUser?.marks.toList() ?? []);
+      return;
+    }
+
     state = const AsyncValue.loading();
     final User? user = ref.read(currentUserProvider);
     final userNotifier = ref.read(currentUserProvider.notifier);

--- a/lib/features/home/viewmodel/outing_reports_viewmodel.dart
+++ b/lib/features/home/viewmodel/outing_reports_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/home/model/general_outing_report.dart';
 import 'package:vit_ap_student_app/features/home/model/weekend_outing_report.dart';
 import 'package:vit_ap_student_app/features/home/repository/outing_local_repository.dart';
@@ -22,6 +23,14 @@ class GeneralOutingReportsViewModel extends _$GeneralOutingReportsViewModel {
   }
 
   Future<void> fetchGeneralOutingReports({bool silentRefresh = false}) async {
+    // Demo mode: serve bundled sample general outing reports.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(
+        await DemoService.instance.generalOutingReports(),
+      );
+      return;
+    }
+
     // Check internet connectivity
     final isConnected = await InternetConnection().hasInternetAccess;
 
@@ -94,6 +103,14 @@ class WeekendOutingReportsViewModel extends _$WeekendOutingReportsViewModel {
   }
 
   Future<void> fetchWeekendOutingReports({bool silentRefresh = false}) async {
+    // Demo mode: serve bundled sample weekend outing reports.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(
+        await DemoService.instance.weekendOutingReports(),
+      );
+      return;
+    }
+
     // Check internet connectivity
     final isConnected = await InternetConnection().hasInternetAccess;
 

--- a/lib/features/home/viewmodel/outing_reports_viewmodel.dart
+++ b/lib/features/home/viewmodel/outing_reports_viewmodel.dart
@@ -27,13 +27,16 @@ class GeneralOutingReportsViewModel extends _$GeneralOutingReportsViewModel {
   /// cache exists) returns `false`, so callers don't advance the "last synced"
   /// timer on a stale result.
   Future<bool> fetchGeneralOutingReports({bool silentRefresh = false}) async {
-        // Demo mode: serve bundled sample general outing reports.
+    // Demo mode: serve bundled sample general outing reports. Reported as a
+    // successful sync — the bundled data is always current for the demo, never
+    // a stale cache fallback — so pull-to-refresh stamps "last synced".
     if (DemoService.isDemoMode) {
       state = AsyncValue.data(
         await DemoService.instance.generalOutingReports(),
       );
-      return;
+      return true;
     }
+
     // Check internet connectivity
     final isConnected = await InternetConnection().hasInternetAccess;
 
@@ -107,13 +110,16 @@ class WeekendOutingReportsViewModel extends _$WeekendOutingReportsViewModel {
   }
 
   Future<bool> fetchWeekendOutingReports({bool silentRefresh = false}) async {
-    // Demo mode: serve bundled sample weekend outing reports.
+    // Demo mode: serve bundled sample weekend outing reports. Reported as a
+    // successful sync — the bundled data is always current for the demo, never
+    // a stale cache fallback — so pull-to-refresh stamps "last synced".
     if (DemoService.isDemoMode) {
       state = AsyncValue.data(
         await DemoService.instance.weekendOutingReports(),
       );
-      return;
+      return true;
     }
+
     // Check internet connectivity
     final isConnected = await InternetConnection().hasInternetAccess;
 

--- a/lib/features/home/viewmodel/payment_receipts_viewmodel.dart
+++ b/lib/features/home/viewmodel/payment_receipts_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/home/model/payment_receipt.dart';
 import 'package:vit_ap_student_app/features/home/repository/home_remote_repository.dart';
 
@@ -19,6 +20,13 @@ class PaymentReceiptsViewModel extends _$PaymentReceiptsViewModel {
 
   Future<void> fetchPendingPayments() async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample payment receipts.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.paymentReceipts());
+      return;
+    }
+
     final credentials = await ref
         .read(currentUserProvider.notifier)
         .getSavedCredentials();

--- a/lib/features/home/viewmodel/pending_payments_viewmodel.dart
+++ b/lib/features/home/viewmodel/pending_payments_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'package:fpdart/fpdart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/home/model/pending_payment.dart';
 import 'package:vit_ap_student_app/features/home/repository/home_remote_repository.dart';
 
@@ -19,6 +20,13 @@ class PendingPaymentsViewModel extends _$PendingPaymentsViewModel {
 
   Future<void> fetchPendingPayments() async {
     state = const AsyncValue.loading();
+
+    // Demo mode: serve bundled sample pending payments.
+    if (DemoService.isDemoMode) {
+      state = AsyncValue.data(await DemoService.instance.pendingPayments());
+      return;
+    }
+
     final credentials = await ref
         .read(currentUserProvider.notifier)
         .getSavedCredentials();

--- a/lib/features/timetable/viewmodel/timetable_viewmodel.dart
+++ b/lib/features/timetable/viewmodel/timetable_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:vit_ap_student_app/core/models/credentials.dart';
 import 'package:vit_ap_student_app/core/models/timetable.dart';
 import 'package:vit_ap_student_app/core/models/user.dart';
 import 'package:vit_ap_student_app/core/providers/current_user.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/features/timetable/repository/timetable_remote_repository.dart';
 
 part 'timetable_viewmodel.g.dart';
@@ -21,6 +22,15 @@ class TimetableViewModel extends _$TimetableViewModel {
   }
 
   Future<void> refreshTimetable() async {
+    // Demo mode: serve the timetable seeded into the user at login.
+    if (DemoService.isDemoMode) {
+      final demoTimetable = ref.read(currentUserProvider)?.timetable.target;
+      if (demoTimetable != null) {
+        state = AsyncValue.data(demoTimetable);
+      }
+      return;
+    }
+
     state = const AsyncValue.loading();
     final User? user = ref.read(currentUserProvider);
     final userNotifier = ref.read(currentUserProvider.notifier);

--- a/lib/init_dependencies.dart
+++ b/lib/init_dependencies.dart
@@ -15,6 +15,7 @@ import 'package:timezone/timezone.dart' as tz;
 import 'package:vit_ap_student_app/core/constants/server_constants.dart';
 import 'package:vit_ap_student_app/core/network/connection_checker.dart';
 import 'package:vit_ap_student_app/core/services/analytics_service.dart';
+import 'package:vit_ap_student_app/core/services/demo_service.dart';
 import 'package:vit_ap_student_app/core/services/notification_service.dart';
 import 'package:vit_ap_student_app/core/services/secure_store_service.dart';
 import 'package:vit_ap_student_app/core/services/vtop_service.dart';

--- a/lib/init_dependencies.main.dart
+++ b/lib/init_dependencies.main.dart
@@ -67,6 +67,9 @@ Future<void> initServices() async {
 
   serviceLocator.registerSingleton<VtopClientService>(VtopClientService());
 
+  // Hydrate the demo-mode flag so it can be read synchronously everywhere.
+  await DemoService.init();
+
   serviceLocator.registerSingleton<ConnectionChecker>(
     ConnectionCheckerImpl(InternetConnection()),
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,6 +88,7 @@ flutter:
     - assets/images/logo/
     - assets/images/icons/
     - assets/weather_icons/
+    - assets/demo/
 
   fonts:
     - family: Poppins

--- a/test/core/services/demo_dataset_test.dart
+++ b/test/core/services/demo_dataset_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vit_ap_student_app/core/models/user.dart';
+import 'package:vit_ap_student_app/features/attendance/model/attendance_detail.dart';
+import 'package:vit_ap_student_app/features/course_page/model/course_page_detail.dart';
+import 'package:vit_ap_student_app/features/course_page/model/courses_response.dart';
+import 'package:vit_ap_student_app/features/course_page/model/slots_response.dart';
+import 'package:vit_ap_student_app/features/digital_assignment/model/digital_assignment_model.dart';
+import 'package:vit_ap_student_app/features/home/model/biometric.dart';
+import 'package:vit_ap_student_app/features/home/model/general_outing_report.dart';
+import 'package:vit_ap_student_app/features/home/model/payment_receipt.dart';
+import 'package:vit_ap_student_app/features/home/model/pending_payment.dart';
+import 'package:vit_ap_student_app/features/home/model/weekend_outing_report.dart';
+import 'package:vit_ap_student_app/src/rust/api/vtop/types/faculty.dart';
+
+/// Validates that the bundled demo dataset deserializes cleanly against every
+/// model DemoService feeds it into. This is the demo login's contract: if any
+/// key drifts from a model's `fromJson`, the reviewer would hit a broken
+/// screen, so we fail fast here instead.
+void main() {
+  late Map<String, dynamic> data;
+
+  setUpAll(() {
+    final file = File('assets/demo/demo_dataset.json');
+    data = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+  });
+
+  test('user (profile/timetable/attendance/marks/exam) parses', () {
+    final user = User.fromJson(data['user'] as Map<String, dynamic>);
+    expect(user.profile.target, isNotNull);
+    expect(user.profile.target!.studentName, isNotEmpty);
+    expect(user.timetable.target, isNotNull);
+    expect(user.attendance, isNotEmpty);
+    expect(user.marks, isNotEmpty);
+    expect(user.examSchedule, isNotEmpty);
+  });
+
+  test('detailed attendance parses', () {
+    final list = (data['detailed_attendance'] as List<dynamic>)
+        .map((e) => AttendanceDetail.fromJson(e as Map<String, dynamic>))
+        .toList();
+    expect(list, isNotEmpty);
+  });
+
+  test('biometric parses', () {
+    final list = (data['biometric'] as List<dynamic>)
+        .map((e) => Biometric.fromJson(e as Map<String, dynamic>))
+        .toList();
+    expect(list, isNotEmpty);
+  });
+
+  test('pending payments parse', () {
+    final list = (data['pending_payments'] as List<dynamic>)
+        .map((e) => PendingPayment.fromJson(e as Map<String, dynamic>))
+        .toList();
+    expect(list, isNotEmpty);
+  });
+
+  test('payment receipts parse', () {
+    final list = (data['payment_receipts'] as List<dynamic>)
+        .map((e) => PaymentReceipt.fromJson(e as Map<String, dynamic>))
+        .toList();
+    expect(list, isNotEmpty);
+  });
+
+  test('general outing reports parse', () {
+    final list = (data['general_outing_reports'] as List<dynamic>)
+        .map((e) => GeneralOutingReport.fromJson(e as Map<String, dynamic>))
+        .toList();
+    expect(list, isNotEmpty);
+  });
+
+  test('weekend outing reports parse (incl. DateTime)', () {
+    final list = (data['weekend_outing_reports'] as List<dynamic>)
+        .map((e) => WeekendOutingReport.fromJson(e as Map<String, dynamic>))
+        .toList();
+    expect(list, isNotEmpty);
+    expect(list.first.date, isA<DateTime>());
+  });
+
+  test('faculty details parse', () {
+    final details =
+        FacultyDetails.fromJson(data['faculty_details'] as Map<String, dynamic>);
+    expect(details.name, isNotEmpty);
+    expect(details.officeHours, isNotEmpty);
+  });
+
+  test('courses parse', () {
+    final res =
+        CoursesResponseModel.fromJson(data['courses'] as Map<String, dynamic>);
+    expect(res.courses, isNotEmpty);
+  });
+
+  test('slots parse', () {
+    final res =
+        SlotsResponseModel.fromJson(data['slots'] as Map<String, dynamic>);
+    expect(res.slots, isNotEmpty);
+    expect(res.classEntries, isNotEmpty);
+  });
+
+  test('course detail parses', () {
+    final detail = CoursePageDetailModel.fromJson(
+        data['course_detail'] as Map<String, dynamic>);
+    expect(detail.courseInfo.courseCode, isNotEmpty);
+    expect(detail.lectures, isNotEmpty);
+  });
+
+  test('digital assignments parse', () {
+    final list = (data['digital_assignments'] as List<dynamic>)
+        .map((e) => DigitalAssignment.fromJson(e as Map<String, dynamic>))
+        .toList();
+    expect(list, isNotEmpty);
+    expect(list.first.details, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `ui` — UI / layout change (include screenshots)
- [ ] `refactor` — code change with no behaviour difference
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `rust` — Rust / VTOP scraping changes
- [ ] `bridge` — Flutter-Rust bridge bindings regenerated

## Related Issue

Closes #36 

## Description

Adds a **Demo Login** option so App Store reviewers (and demos) can evaluate the
app without a real VTOP account. Real login requires an email OTP that can't be
shared with reviewers, which currently blocks App Store review.

Entering the predefined demo credentials on the login screen bypasses the entire
VTOP authentication flow — no OTP, no semester selection — and seeds the app from
a locally bundled, fully sanitized dataset. No real student data is exposed and no
network request reaches VTOP while demo mode is active.

## Changes Made

- Add `DemoService` (`lib/core/services/demo_service.dart`): demo credentials,
  `isDemoMode` flag (cached in memory, persisted via `SharedPreferences`,
  hydrated in `initDependencies`), and typed loaders for the bundled dataset.
- Add bundled sample dataset `assets/demo/demo_dataset.json` (registered in
  `pubspec.yaml`); text-only, ~14 KB.
- `LoginPage` detects demo credentials and routes straight into the app;
  `AuthViewModel.loginDemoUser()` seeds the demo `User` and enables demo mode.
- Central guard: `VtopClientService.getClient` throws `DemoModeException` in demo
  mode so no path can reach VTOP with placeholder credentials.
- Feature view models short-circuit in demo mode — primary data (attendance,
  marks, timetable, exam schedule) is served from the cached demo `User`;
  secondary reads (detailed attendance, biometric, payments, outing reports,
  faculty details, courses/slots/course detail, digital assignments, account
  sync) are served from `DemoService`.
- Hide write/download entry points in demo mode: Manage Credentials tile, outing
  "Apply" buttons, assignment Upload/Update. Outing PDF / course material /
  assignment file downloads self-hide via the dataset's `can_*`/path fields.
- `CurrentUserNotifier.logout()` clears the demo flag.
- Add `test/core/services/demo_dataset_test.dart` deserializing every dataset
  section against its model.

## Checklist

### Flutter

- [x] `flutter analyze` passes with no new warnings
- [x] `flutter test` passes *(new demo-dataset tests pass; the only failing test is the pre-existing boilerplate `test/widget_test.dart` counter smoke test, unrelated to this change)*
- [ ] Ran `dart run build_runner build --delete-conflicting-outputs` — N/A (no model, provider, or ObjectBox entity added or modified; only a method added to an existing notifier)
- [x] No new `debugPrint` calls left in production paths that should be removed

### Rust (skip if no Rust changes)

- [ ] `cargo fmt` run inside `rust/`
- [ ] `cargo clippy` passes with no new warnings inside `rust/`
- [ ] `cargo test` passes inside `rust/`
- [ ] Ran `flutter_rust_bridge_codegen generate` and committed the updated `lib/src/rust/` bindings

_No Rust / bridge changes._

### Testing

- [x] Tested on Android
- [ ] Tested on iOS *(or noted why not applicable)*
- [x] Existing features unaffected by this change *(demo mode is fully gated behind `DemoService.isDemoMode`; normal login path untouched)*